### PR TITLE
#39-Fix getting the current branch from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # :ghost: __semver-git-plugin__
-*Version your gradle projects with git tags and semantic versioning.*
+*Version your gradle projects with git tags and semantic versioning. Requires git 2.22 or higher*
 
 [![GitHub version](https://img.shields.io/github/tag/ilovemilk/semver-git-plugin.svg)](https://img.shields.io/github/tag/ilovemilk/semver-git-plugin.svg)
 [![License](https://img.shields.io/github/license/ilovemilk/semver-git-plugin.svg)](https://img.shields.io/github/license/ilovemilk/semver-git-plugin.svg)

--- a/src/main/kotlin/io/wusa/GitService.kt
+++ b/src/main/kotlin/io/wusa/GitService.kt
@@ -9,7 +9,7 @@ class GitService {
         @Throws(NoCurrentBranchFoundException::class)
         fun currentBranch(project: Project): String {
             return try {
-                val branches = getAllBranches(project)
+                val branches = getCurrentBranch(project)
                 filterCurrentBranch(branches)
             } catch (ex: GitException) {
                 throw NoCurrentBranchFoundException(ex)
@@ -90,6 +90,11 @@ class GitService {
 
         private fun filterCurrentBranch(branches: String) =
                 """(\*)? +(.*?) +(.*?)?""".toRegex().find(branches)!!.groupValues[2]
+
+        private fun getCurrentBranch(project: Project): String {
+            val branchName = GitCommandRunner.execute(project.projectDir, arrayOf("branch", "--show-current"))
+            return GitCommandRunner.execute(project.projectDir, arrayOf("branch", branchName, "--verbose", "--no-abbrev", "--contains"))
+        }
 
         private fun getAllBranches(project: Project): String {
             return GitCommandRunner.execute(project.projectDir, arrayOf("branch", "--all", "--verbose", "--no-abbrev", "--contains"))


### PR DESCRIPTION
See issue https://github.com/ilovemilk/semver-git-plugin/issues/39 which has two parts to it.  This fix is for a single part where the current branch name was not being determined correctly.  

The fix is use the --show-current option from Git and then feed that to the original commandline that obtained all the "info" related to the branch.